### PR TITLE
fix: directly referenced images via digest get deleted even if running

### DIFF
--- a/main.py
+++ b/main.py
@@ -118,6 +118,14 @@ def discover_delete_images(regionname):
                     if imageurl == runningimages:
                         if imageurl not in running_sha:
                             running_sha.append(image['imageDigest'])
+            # check for directly referenced sha
+            for running_image in running_containers:
+                running_digest_match = re.search(r"[^@]+$", running_image)
+                if running_digest_match:
+                    running_digest = running_digest_match.group()
+                    if running_digest == running_image:
+                        if image['imageDigest'] not in running_sha:
+                            running_sha.append(image['imageDigest'])
 
         print("Number of running images found {}".format(len(running_sha)))
         ignore_tags_regex = re.compile(IGNORE_TAGS_REGEX)


### PR DESCRIPTION
This fix adds images to the list of running shas if they are directly referenced by the sha digest and not by tag